### PR TITLE
Fix: check whole true/false/null tokens

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,8 +162,25 @@ impl Tokenizer<'_> {
 
     fn next_true(&mut self) -> Option<Token> {
         // we know prev char is t
-        for _ in 0..4 {
-            self.to_parse.next();
+
+        let mut failed = false;
+
+        "true".chars().for_each(|c| {
+            if let Some(parsed_c) = self.to_parse.next() {
+                if c != parsed_c {
+                    println!("Couldn't parse true");
+                    failed = true;
+                    return;
+                }
+            } else {
+                println!("Unexpected EOF");
+                failed = true;
+                return;
+            }
+        });
+
+        if failed {
+            return None;
         }
 
         Some(Token::Value(Bool(true)))
@@ -171,17 +188,50 @@ impl Tokenizer<'_> {
 
     fn next_false(&mut self) -> Option<Token> {
         // we know prev char is f
-        for _ in 0..5 {
-            self.to_parse.next();
-        }
 
+        let mut failed = false;
+
+        "false".chars().for_each(|c| {
+            if let Some(parsed_c) = self.to_parse.next() {
+                if c != parsed_c {
+                    println!("Couldn't parse true");
+                    failed = true;
+                    return;
+                }
+            } else {
+                println!("Unexpected EOF");
+                failed = true;
+                return;
+            }
+        });
+
+        if failed {
+            return None;
+        }
         Some(Token::Value(Bool(false)))
     }
 
     fn next_null(&mut self) -> Option<Token> {
         // we know prev char is n
-        for _ in 0..4 {
-            self.to_parse.next();
+
+        let mut failed = false;
+
+        "null".chars().for_each(|c| {
+            if let Some(parsed_c) = self.to_parse.next() {
+                if c != parsed_c {
+                    println!("Couldn't parse true");
+                    failed = true;
+                    return;
+                }
+            } else {
+                println!("Unexpected EOF");
+                failed = true;
+                return;
+            }
+        });
+
+        if failed {
+            return None;
         }
 
         Some(Token::Value(Null))


### PR DESCRIPTION
Previously any 4-, respectively 5-character sequence starting with the correct character parsed as a valid `true`/`false`/`null`. This PR checks the whole token 1:1 for correct characters. 